### PR TITLE
fix: cron URL generation for correct module route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - French translation for the module
 - Display customer note back office
 - Display a redirection to the customer profile in the back office
+- Front controller cron tests 
 
 ### Fixed
 
@@ -20,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - isUsingNewTranslationSystem method to use the correct translation system
 - KYC checkout step not shown for products with non-default categories
 - fallback emails for KYC notifications / status (add html and text versions)
+- Cron endpoint for KYC document cleanup and expiration emails
 
 ## [1.0.0] - 2025-06-01
 

--- a/config/front/services.yml
+++ b/config/front/services.yml
@@ -54,3 +54,14 @@ services:
       - '@PrestaShop\Module\Pskyc\Repository\LogRepository'
       - '@PrestaShop\Module\Pskyc\Service\NotificationService'
       - '@PrestaShop\Module\Pskyc\Repository\CustomerRepository'
+
+  PrestaShop\Module\Pskyc\Service\MaintenanceService:
+    class: 'PrestaShop\Module\Pskyc\Service\MaintenanceService'
+    arguments:
+      - '@PrestaShop\Module\Pskyc\Service\DocumentService'
+      - '@PrestaShop\Module\Pskyc\Service\NotificationService'
+      - '@PrestaShop\Module\Pskyc\Repository\VerificationRepository'
+      - '@PrestaShop\Module\Pskyc\Repository\DocumentRepository'
+      - '@PrestaShop\Module\Pskyc\Repository\CustomerRepository'
+      - '@PrestaShop\Module\Pskyc\Repository\LogRepository'
+      

--- a/controllers/front/cron.php
+++ b/controllers/front/cron.php
@@ -100,6 +100,10 @@ class PskycCronModuleFrontController extends ModuleFrontController
     private function initializeServices()
     {
         try {
+            if (!$this->module) {
+                $this->module = Module::getInstanceByName('pskyc');
+            }
+
             $this->maintenanceService = $this->module->get('PrestaShop\Module\Pskyc\Service\MaintenanceService');
         } catch (Exception $e) {
             PrestaShopLogger::addLog('Service initialization failed: ' . $e->getMessage(), 3, null, 'Pskyc');

--- a/controllers/front/cron.php
+++ b/controllers/front/cron.php
@@ -12,6 +12,8 @@ if (!defined('_PS_VERSION_')) {
     exit;
 }
 
+use PrestaShop\Module\Pskyc\Service\MaintenanceService;
+
 /**
  * KYC Secure Upload Cron Controller
  *
@@ -25,7 +27,7 @@ class PskycCronModuleFrontController extends ModuleFrontController
     public $module;
 
     /**
-     * @var PrestaShop\Module\Pskyc\Service\MaintenanceService
+     * @var MaintenanceService
      */
     private $maintenanceService;
 
@@ -100,10 +102,6 @@ class PskycCronModuleFrontController extends ModuleFrontController
     private function initializeServices()
     {
         try {
-            if (!$this->module) {
-                $this->module = Module::getInstanceByName('pskyc');
-            }
-
             $this->maintenanceService = $this->module->get('PrestaShop\Module\Pskyc\Service\MaintenanceService');
         } catch (Exception $e) {
             PrestaShopLogger::addLog('Service initialization failed: ' . $e->getMessage(), 3, null, 'Pskyc');

--- a/src/Service/MaintenanceService.php
+++ b/src/Service/MaintenanceService.php
@@ -450,14 +450,19 @@ class MaintenanceService
     public function generateCronUrl(string $action = 'daily_maintenance'): string
     {
         $token = $this->getCronToken();
-        $shopUrl = \Tools::getShopDomainSsl(true, true);
 
-        // Build the cron URL pointing to your module's cron endpoint
-        return sprintf(
-            '%s/modules/pskyc/cron.php?token=%s&action=%s',
-            rtrim($shopUrl, '/'),
-            $token,
-            urlencode($action)
+        $context = \Context::getContext();
+        $link = $context->link;
+
+        return $link->getModuleLink(
+            'pskyc',
+            'cron',
+            [
+                'token' => $token,
+                'action' => $action,
+            ],
+            true,
+            $context->language->id
         );
     }
 }

--- a/tests/PsKyc/Controller/CronControllerTest.php
+++ b/tests/PsKyc/Controller/CronControllerTest.php
@@ -1,0 +1,155 @@
+<?php
+
+namespace Tests\PsKyc\Controller;
+
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryTestCase;
+
+// Load the ModuleFrontController stub and the controller under test
+require_once __DIR__ . '/../Mock/ModuleFrontController.php';
+require_once dirname(__DIR__, 3) . '/controllers/front/cron.php';
+
+class CronControllerTest extends MockeryTestCase
+{
+    /** @var Mockery\MockInterface */
+    private $maintenanceServiceMock;
+
+    /** @var Mockery\MockInterface */
+    private $moduleMock;
+
+    /** @var Mockery\MockInterface */
+    private $moduleStaticMock;
+
+    /** @var Mockery\MockInterface */
+    private $toolsMock;
+
+    /** @var Mockery\MockInterface */
+    private $loggerMock;
+
+    protected function setUp(): void
+    {
+        $this->maintenanceServiceMock = \Mockery::mock();
+        $this->moduleMock = \Mockery::mock();
+        $this->moduleStaticMock = \Mockery::mock();
+        $this->toolsMock = \Mockery::mock();
+        $this->loggerMock = \Mockery::mock();
+
+        \Module::setStaticExpectations($this->moduleStaticMock);
+        \Tools::setStaticExpectations($this->toolsMock);
+        \PrestaShopLogger::setStaticExpectations($this->loggerMock);
+
+        $this->loggerMock->shouldReceive('addLog')->byDefault();
+
+        $this->moduleStaticMock->shouldReceive('getInstanceByName')
+            ->with('pskyc')
+            ->andReturn($this->moduleMock);
+
+        $this->moduleMock->shouldReceive('get')
+            ->with('PrestaShop\\Module\\Pskyc\\Service\\MaintenanceService')
+            ->andReturn($this->maintenanceServiceMock)
+            ->byDefault();
+    }
+
+    public function testDailyMaintenanceSuccess()
+    {
+        $token = 'token123';
+        $results = ['success' => true];
+
+        $this->maintenanceServiceMock->shouldReceive('getCronToken')
+            ->once()
+            ->andReturn($token);
+        $this->maintenanceServiceMock->shouldReceive('runDailyMaintenance')
+            ->once()
+            ->andReturn($results);
+        $this->maintenanceServiceMock->shouldReceive('logMaintenanceRun')
+            ->once()
+            ->with($results);
+
+        $this->toolsMock->shouldReceive('getValue')
+            ->with('token')
+            ->andReturn($token);
+        $this->toolsMock->shouldReceive('getValue')
+            ->with('action', 'daily_maintenance')
+            ->andReturn('daily_maintenance');
+
+        $controller = new \PskycCronModuleFrontController();
+        set_error_handler(function () {});
+        ob_start();
+        $controller->postProcess();
+        ob_end_clean();
+        restore_error_handler();
+
+        $this->assertSame(json_encode($results), $controller->output);
+    }
+
+    public function testInvalidToken()
+    {
+        $token = 'token123';
+
+        $this->maintenanceServiceMock->shouldReceive('getCronToken')
+            ->once()
+            ->andReturn($token);
+
+        $this->toolsMock->shouldReceive('getValue')
+            ->with('token')
+            ->andReturn('wrong');
+        $this->toolsMock->shouldReceive('getValue')
+            ->with('action', 'daily_maintenance')
+            ->andReturn('daily_maintenance');
+
+        $controller = new \PskycCronModuleFrontController();
+        set_error_handler(function () {});
+        ob_start();
+        $controller->postProcess();
+        ob_end_clean();
+        restore_error_handler();
+
+        $this->assertSame('Bad token', $controller->output);
+    }
+
+    public function testServiceInitializationFailure()
+    {
+        $this->moduleMock->shouldReceive('get')
+            ->with('PrestaShop\\Module\\Pskyc\\Service\\MaintenanceService')
+            ->once()
+            ->andThrow(new \Exception('no service'));
+
+        $this->loggerMock->shouldReceive('addLog')
+            ->once()
+            ->with('Cron service initialization failed: MaintenanceService not available', 3, null, 'Pskyc');
+
+        $controller = new \PskycCronModuleFrontController();
+        set_error_handler(function () {});
+        ob_start();
+        $controller->postProcess();
+        ob_end_clean();
+        restore_error_handler();
+
+        $this->assertSame('Service initialization failed', $controller->output);
+    }
+
+    public function testUnknownAction()
+    {
+        $token = 'token123';
+
+        $this->maintenanceServiceMock->shouldReceive('getCronToken')
+            ->once()
+            ->andReturn($token);
+
+        $this->toolsMock->shouldReceive('getValue')
+            ->with('token')
+            ->andReturn($token);
+        $this->toolsMock->shouldReceive('getValue')
+            ->with('action', 'daily_maintenance')
+            ->andReturn('invalid');
+
+        $controller = new \PskycCronModuleFrontController();
+        set_error_handler(function () {});
+        ob_start();
+        $controller->postProcess();
+        ob_end_clean();
+        restore_error_handler();
+
+        $this->assertSame('Unknown action', $controller->output);
+    }
+}

--- a/tests/PsKyc/Mock/ModuleFrontController.php
+++ b/tests/PsKyc/Mock/ModuleFrontController.php
@@ -1,0 +1,17 @@
+<?php
+
+class ModuleFrontController
+{
+    public $ajax = false;
+    public $module;
+    public $output = '';
+
+    public function __construct()
+    {
+    }
+
+    public function ajaxRender(string $content)
+    {
+        $this->output = $content;
+    }
+}

--- a/tests/PsKyc/Service/MaintenanceServiceTest.php
+++ b/tests/PsKyc/Service/MaintenanceServiceTest.php
@@ -1174,7 +1174,6 @@ class MaintenanceServiceTest extends MockeryTestCase
     {
         $encryptionKey = 'test_encryption_key_12345';
         $expectedToken = 'abcdefghij';
-        $shopUrl = 'https://mystore.com';
         $action = 'daily_maintenance';
 
         // Mock Configuration::get() to return encryption key
@@ -1192,18 +1191,25 @@ class MaintenanceServiceTest extends MockeryTestCase
             ->once()
             ->with($encryptionKey . 'pskyc_cron_token')
             ->andReturn($expectedToken . 'extra_chars_to_be_truncated');
-
-        // Mock Tools::getShopDomainSsl() to return shop URL
-        $toolsMock->shouldReceive('getShopDomainSsl')
-            ->once()
-            ->with(true, true)
-            ->andReturn($shopUrl);
-
         \Tools::setStaticExpectations($toolsMock);
+
+        // Mock Context with Link
+        $linkMock = \Mockery::mock();
+        $languageMock = \Mockery::mock();
+        $languageMock->id = 1;
+        $contextMock = \Mockery::mock();
+        $contextMock->link = $linkMock;
+        $contextMock->language = $languageMock;
+        \Context::setStaticExpectations($contextMock);
+
+        $expectedUrl = 'https://mystore.com/fr/module/pskyc/cron?token=abcdefghij&action=daily_maintenance';
+        $linkMock->shouldReceive('getModuleLink')
+            ->once()
+            ->with('pskyc', 'cron', ['token' => $expectedToken, 'action' => $action], true, 1)
+            ->andReturn($expectedUrl);
 
         $result = $this->maintenanceService->generateCronUrl($action);
 
-        $expectedUrl = 'https://mystore.com/modules/pskyc/cron.php?token=abcdefghij&action=daily_maintenance';
         $this->assertEquals($expectedUrl, $result);
     }
 
@@ -1211,7 +1217,6 @@ class MaintenanceServiceTest extends MockeryTestCase
     {
         $encryptionKey = 'test_encryption_key_12345';
         $expectedToken = 'xyz1234567';
-        $shopUrl = 'https://example.com/shop';
         $action = 'cleanup_documents';
 
         // Mock Configuration::get() to return encryption key
@@ -1229,18 +1234,25 @@ class MaintenanceServiceTest extends MockeryTestCase
             ->once()
             ->with($encryptionKey . 'pskyc_cron_token')
             ->andReturn($expectedToken . 'more_chars');
-
-        // Mock Tools::getShopDomainSsl() to return shop URL
-        $toolsMock->shouldReceive('getShopDomainSsl')
-            ->once()
-            ->with(true, true)
-            ->andReturn($shopUrl);
-
         \Tools::setStaticExpectations($toolsMock);
+
+        // Mock Context with Link
+        $linkMock = \Mockery::mock();
+        $languageMock = \Mockery::mock();
+        $languageMock->id = 1;
+        $contextMock = \Mockery::mock();
+        $contextMock->link = $linkMock;
+        $contextMock->language = $languageMock;
+        \Context::setStaticExpectations($contextMock);
+
+        $expectedUrl = 'https://example.com/shop/fr/module/pskyc/cron?token=xyz1234567&action=cleanup_documents';
+        $linkMock->shouldReceive('getModuleLink')
+            ->once()
+            ->with('pskyc', 'cron', ['token' => $expectedToken, 'action' => $action], true, 1)
+            ->andReturn($expectedUrl);
 
         $result = $this->maintenanceService->generateCronUrl($action);
 
-        $expectedUrl = 'https://example.com/shop/modules/pskyc/cron.php?token=xyz1234567&action=cleanup_documents';
         $this->assertEquals($expectedUrl, $result);
     }
 
@@ -1248,7 +1260,6 @@ class MaintenanceServiceTest extends MockeryTestCase
     {
         $encryptionKey = 'test_key';
         $expectedToken = 'token12345';
-        $shopUrl = 'https://test.com/subfolder/';  // URL with trailing slash
         $action = 'daily_maintenance';
 
         // Mock Configuration::get() to return encryption key
@@ -1266,19 +1277,25 @@ class MaintenanceServiceTest extends MockeryTestCase
             ->once()
             ->with($encryptionKey . 'pskyc_cron_token')
             ->andReturn($expectedToken . 'suffix');
-
-        // Mock Tools::getShopDomainSsl() to return shop URL with trailing slash
-        $toolsMock->shouldReceive('getShopDomainSsl')
-            ->once()
-            ->with(true, true)
-            ->andReturn($shopUrl);
-
         \Tools::setStaticExpectations($toolsMock);
+
+        // Mock Context with Link
+        $linkMock = \Mockery::mock();
+        $languageMock = \Mockery::mock();
+        $languageMock->id = 1;
+        $contextMock = \Mockery::mock();
+        $contextMock->link = $linkMock;
+        $contextMock->language = $languageMock;
+        \Context::setStaticExpectations($contextMock);
+
+        $expectedUrl = 'https://test.com/subfolder/fr/module/pskyc/cron?token=token12345&action=daily_maintenance';
+        $linkMock->shouldReceive('getModuleLink')
+            ->once()
+            ->with('pskyc', 'cron', ['token' => $expectedToken, 'action' => $action], true, 1)
+            ->andReturn($expectedUrl);
 
         $result = $this->maintenanceService->generateCronUrl($action);
 
-        // The trailing slash should be removed by rtrim()
-        $expectedUrl = 'https://test.com/subfolder/modules/pskyc/cron.php?token=token12345&action=daily_maintenance';
         $this->assertEquals($expectedUrl, $result);
     }
 
@@ -1286,7 +1303,6 @@ class MaintenanceServiceTest extends MockeryTestCase
     {
         $encryptionKey = 'default_test_key';
         $expectedToken = 'default123';
-        $shopUrl = 'https://default.com';
 
         // Mock Configuration::get() to return encryption key
         $configurationMock = \Mockery::mock();
@@ -1303,19 +1319,26 @@ class MaintenanceServiceTest extends MockeryTestCase
             ->once()
             ->with($encryptionKey . 'pskyc_cron_token')
             ->andReturn($expectedToken . 'extra');
-
-        // Mock Tools::getShopDomainSsl() to return shop URL
-        $toolsMock->shouldReceive('getShopDomainSsl')
-            ->once()
-            ->with(true, true)
-            ->andReturn($shopUrl);
-
         \Tools::setStaticExpectations($toolsMock);
+
+        // Mock Context with Link
+        $linkMock = \Mockery::mock();
+        $languageMock = \Mockery::mock();
+        $languageMock->id = 1;
+        $contextMock = \Mockery::mock();
+        $contextMock->link = $linkMock;
+        $contextMock->language = $languageMock;
+        \Context::setStaticExpectations($contextMock);
+
+        $expectedUrl = 'https://default.com/fr/module/pskyc/cron?token=default123&action=daily_maintenance';
+        $linkMock->shouldReceive('getModuleLink')
+            ->once()
+            ->with('pskyc', 'cron', ['token' => $expectedToken, 'action' => 'daily_maintenance'], true, 1)
+            ->andReturn($expectedUrl);
 
         // Call without action parameter (should use default)
         $result = $this->maintenanceService->generateCronUrl();
 
-        $expectedUrl = 'https://default.com/modules/pskyc/cron.php?token=default123&action=daily_maintenance';
         $this->assertEquals($expectedUrl, $result);
     }
 

--- a/tests/PsKyc/controllers/front/CronControllerFrontTest.php
+++ b/tests/PsKyc/controllers/front/CronControllerFrontTest.php
@@ -6,10 +6,10 @@ use Mockery;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
 
 // Load the ModuleFrontController stub and the controller under test
-require_once __DIR__ . '/../Mock/ModuleFrontController.php';
-require_once dirname(__DIR__, 3) . '/controllers/front/cron.php';
+require_once dirname(__DIR__, 2) . '/Mock/ModuleFrontController.php';
+require_once dirname(__DIR__, 4) . '/controllers/front/cron.php';
 
-class CronControllerTest extends MockeryTestCase
+class CronControllerFrontTest extends MockeryTestCase
 {
     /** @var Mockery\MockInterface */
     private $maintenanceServiceMock;
@@ -73,6 +73,7 @@ class CronControllerTest extends MockeryTestCase
             ->andReturn('daily_maintenance');
 
         $controller = new \PskycCronModuleFrontController();
+        $controller->module = $this->moduleMock;
         set_error_handler(function () {});
         ob_start();
         $controller->postProcess();
@@ -98,6 +99,7 @@ class CronControllerTest extends MockeryTestCase
             ->andReturn('daily_maintenance');
 
         $controller = new \PskycCronModuleFrontController();
+        $controller->module = $this->moduleMock;
         set_error_handler(function () {});
         ob_start();
         $controller->postProcess();
@@ -119,6 +121,7 @@ class CronControllerTest extends MockeryTestCase
             ->with('Cron service initialization failed: MaintenanceService not available', 3, null, 'Pskyc');
 
         $controller = new \PskycCronModuleFrontController();
+        $controller->module = $this->moduleMock;
         set_error_handler(function () {});
         ob_start();
         $controller->postProcess();
@@ -144,6 +147,7 @@ class CronControllerTest extends MockeryTestCase
             ->andReturn('invalid');
 
         $controller = new \PskycCronModuleFrontController();
+        $controller->module = $this->moduleMock;
         set_error_handler(function () {});
         ob_start();
         $controller->postProcess();


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

## Linked issue
<!-- Please link the issue this PR addresses. (if applicable) -->
Closes #1

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Documentation update
- [ ] Other (please describe):

## Description

- use `Context::getContext()->link->getModuleLink()` to build cron URLs
- update tests for new cron URL format

## How to test

- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_684060fb68448328a33e0537b1450538