### PR TITLE
fix: email template fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Logo image for the module
 - French translation for the module
+- Display customer note back office
+- Display a redirection to the customer profile in the back office
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - .htaccess too complex and blocking logo.png
 - isUsingNewTranslationSystem method to use the correct translation system
 - KYC checkout step not shown for products with non-default categories
-
+- fallback emails for KYC notifications / status (add html and text versions)
 
 ## [1.0.0] - 2025-06-01
 

--- a/mails/en/admin_new_verification.html
+++ b/mails/en/admin_new_verification.html
@@ -1,0 +1,8 @@
+<p>A new KYC verification request has been submitted and requires admin review.</p>
+<p>Customer: {customer_name} ({customer_email})<br>
+Customer ID: #{customer_id}<br>
+Verification ID: #{verification_id}<br>
+Documents Count: {documents_count}</p>
+<p>Please review the submitted documents and update the verification status in the admin panel.</p>
+<p>Review in Admin Panel: {admin_verification_url}</p>
+<p>This is an automated admin notification.</p>

--- a/mails/en/document_upload_confirmation.html
+++ b/mails/en/document_upload_confirmation.html
@@ -1,0 +1,8 @@
+<p>Dear {firstname} {lastname},</p>
+<p>Thank you for uploading your KYC verification documents.</p>
+<p>Verification ID: {verification_id}<br>
+Upload Date: {upload_date}<br>
+Number of Documents: {document_count}</p>
+<p>Our verification team will review your documents within 24-48 hours. You will receive an email notification once the review is complete.</p>
+<p>Check Status: {verification_status_url}</p>
+<p>This is an automated message. Please do not reply to this email.</p>

--- a/mails/en/verification_expiry_warning.html
+++ b/mails/en/verification_expiry_warning.html
@@ -1,0 +1,10 @@
+<p>Dear {firstname} {lastname},</p>
+<p>Your KYC verification is approaching its expiry date.</p>
+<p>Verification ID: {verification_id}<br>
+Current Status: Approved<br>
+Expires On: {expiry_date}<br>
+Days Remaining: {days_remaining}</p>
+<p>To maintain uninterrupted access to our services, please renew your KYC verification before the expiry date.</p>
+<p>Renew Verification: {renewal_url}</p>
+<p>If you have any questions, please contact our support team.<br>
+This is an automated message. Please do not reply to this email.</p>

--- a/mails/en/verification_status.html
+++ b/mails/en/verification_status.html
@@ -1,0 +1,6 @@
+<p>Dear {firstname} {lastname},</p>
+<p>Your KYC verification status has been updated.</p>
+<p>Verification ID: {verification_id}<br>
+Status: {status_label}<br>
+Date Submitted: {date_submitted}</p>
+<p>Message: {status_message}</p>

--- a/mails/fr/admin_new_verification.html
+++ b/mails/fr/admin_new_verification.html
@@ -1,0 +1,8 @@
+<p>Une nouvelle demande de vérification KYC a été soumise et doit être examinée par l'administrateur.</p>
+<p>Client : {customer_name} ({customer_email})<br>
+Identifiant client : #{customer_id}<br>
+Identifiant de vérification : #{verification_id}<br>
+Nombre de documents : {documents_count}</p>
+<p>Veuillez examiner les documents soumis et mettre à jour le statut de vérification dans le panneau d'administration.</p>
+<p>Examen dans le panneau d'administration : {admin_verification_url}</p>
+<p>Il s'agit d'une notification administrative automatisée.</p>

--- a/mails/fr/document_upload_confirmation.html
+++ b/mails/fr/document_upload_confirmation.html
@@ -1,0 +1,8 @@
+<p>Une nouvelle demande de vérification KYC a été soumise et doit être examinée par l'administrateur.</p>
+<p>Client : {customer_name} ({customer_email})<br>
+Identifiant client : #{customer_id}<br>
+Identifiant de vérification : #{verification_id}<br>
+Nombre de documents : {documents_count}</p>
+<p>Veuillez examiner les documents soumis et mettre à jour le statut de vérification dans le panneau d'administration.</p>
+<p>Examen dans le panneau d'administration : {admin_verification_url}</p>
+<p>Il s'agit d'une notification administrative automatisée.</p>

--- a/mails/fr/verification_expiry_warning.html
+++ b/mails/fr/verification_expiry_warning.html
@@ -1,0 +1,10 @@
+<p>Cher {prénom} {nom},</p>
+<p>Votre vérification KYC arrive bientôt à expiration.</p>
+<p>Identifiant de vérification : {verification_id}<br>
+Statut actuel : Approuvé<br>
+Date d'expiration : {expiry_date}<br>
+Jours restants : {days_remaining}</p>
+<p>Pour continuer à bénéficier d'un accès ininterrompu à nos services, veuillez renouveler votre vérification KYC avant la date d'expiration.</p>
+<p>Renouveler la vérification : {renewal_url}</p>
+<p>Si vous avez des questions, veuillez contacter notre équipe d'assistance.<br>
+Ceci est un message automatique. Veuillez ne pas répondre à cet e-mail.</p>

--- a/mails/fr/verification_status.html
+++ b/mails/fr/verification_status.html
@@ -1,0 +1,6 @@
+<p>Cher {prénom} {nom},</p>
+<p>Le statut de votre vérification KYC a été mis à jour.</p>
+<p>ID de vérification : {verification_id}<br>
+Statut : {status_label}<br>
+Date de soumission : {date_submitted}</p>
+<p>Message : {status_message}</p>

--- a/src/Service/NotificationService.php
+++ b/src/Service/NotificationService.php
@@ -383,7 +383,7 @@ class NotificationService
             $modulePath = _PS_MODULE_DIR_ . 'pskyc/mails/';
 
             $useModulePath = !file_exists($themePath . $langIso . '/' . $template . '.txt')
-                && !file_exists($themePath . $langIso . '/' . $template . '.html');
+                || !file_exists($themePath . $langIso . '/' . $template . '.html');
 
             return \Mail::Send(
                 $langId,

--- a/src/Service/NotificationService.php
+++ b/src/Service/NotificationService.php
@@ -378,7 +378,13 @@ class NotificationService
                 $langId = (int) \Configuration::get('PS_LANG_DEFAULT');
             }
 
-            // Use PrestaShop's Mail::Send method
+            $langIso = \Language::getIsoById($langId);
+            $themePath = _PS_THEME_DIR_ . 'modules/pskyc/mails/';
+            $modulePath = _PS_MODULE_DIR_ . 'pskyc/mails/';
+
+            $useModulePath = !file_exists($themePath . $langIso . '/' . $template . '.txt')
+                && !file_exists($themePath . $langIso . '/' . $template . '.html');
+
             return \Mail::Send(
                 $langId,
                 $template,
@@ -386,15 +392,15 @@ class NotificationService
                 $templateVars,
                 $recipientEmail,
                 $recipientName,
-                null, // from email (use default)
-                null, // from name (use default)
-                null, // file attachment
-                null, // mode_smtp
-                _PS_MODULE_DIR_ . 'pskyc/mails/', // template_path
-                false, // die
-                null, // id_shop
-                null, // bcc
-                null  // reply_to
+                null,
+                null,
+                null,
+                null,
+                $useModulePath ? $modulePath : null,
+                false,
+                null,
+                null,
+                null
             );
         } catch (\Exception $e) {
             \PrestaShopLogger::addLog('Theme email error: ' . $e->getMessage(), 3, null, 'Pskyc');

--- a/tests/PsKyc/MockProxy.php
+++ b/tests/PsKyc/MockProxy.php
@@ -91,6 +91,11 @@ class Shop extends MockProxy
 class Language extends MockProxy
 {
     protected static $mock;
+
+    public static function getIsoById($id)
+    {
+        return 'en';
+    }
 }
 
 class Customer extends MockProxy

--- a/tests/PsKyc/Service/NotificationServiceTest.php
+++ b/tests/PsKyc/Service/NotificationServiceTest.php
@@ -626,8 +626,10 @@ class NotificationServiceTest extends MockeryTestCase
 
         foreach (['en', 'fr'] as $lang) {
             foreach ($templates as $template) {
-                $file = $mailsPath . $lang . '/' . $template . '.txt';
-                $this->assertFileExists($file, "Missing fallback text template $file");
+                $txt = $mailsPath . $lang . '/' . $template . '.txt';
+                $html = $mailsPath . $lang . '/' . $template . '.html';
+                $this->assertFileExists($txt, "Missing fallback text template $txt");
+                $this->assertFileExists($html, "Missing fallback html template $html");
             }
         }
 

--- a/tests/PsKyc/Service/NotificationServiceTest.php
+++ b/tests/PsKyc/Service/NotificationServiceTest.php
@@ -612,6 +612,35 @@ class NotificationServiceTest extends MockeryTestCase
         $this->assertFalse($result);
     }
 
+    public function testFallbackTemplatesExist()
+    {
+        $rootPath = dirname(__DIR__, 3);
+        $mailsPath = $rootPath . '/mails/';
+
+        $templates = [
+            'verification_status',
+            'document_upload_confirmation',
+            'admin_new_verification',
+            'verification_expiry_warning',
+        ];
+
+        foreach (['en', 'fr'] as $lang) {
+            foreach ($templates as $template) {
+                $file = $mailsPath . $lang . '/' . $template . '.txt';
+                $this->assertFileExists($file, "Missing fallback text template $file");
+            }
+        }
+
+        $layoutBase = $mailsPath . 'layouts/';
+        foreach ($templates as $template) {
+            $this->assertFileExists($layoutBase . $template . '.html.twig');
+            foreach (['classic', 'modern'] as $theme) {
+                $layout = $layoutBase . $theme . '/' . $template . '.html.twig';
+                $this->assertFileExists($layout);
+            }
+        }
+    }
+
     /**
      * Helper method to set up Context expectations
      */

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -14,6 +14,7 @@ require_once __DIR__ . '/PsKyc/Mock/VirtualFileSystem.php';
 require_once __DIR__ . '/PsKyc/Mock/VirtualFileSystemAdapter.php';
 
 define('_PS_MODULE_DIR_', __DIR__ . '/../modules/pskyc/');
+define('_PS_THEME_DIR_', __DIR__ . '/../themes/default/');
 
 function pSQL($string, $htmlOK = false)
 {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

## Linked issue
<!-- Please link the issue this PR addresses. (if applicable) -->
Closes #5 

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Documentation update
- [ ] Other (please describe):

## Description

- implement fallback check in `NotificationService` so the module path is only used when the theme template is missing
- provide `Language::getIsoById` mock
- define `_PS_THEME_DIR_` in tests bootstrap

## How to test
- `composer lint-check`
- `./vendor/bin/phpunit -c tests/phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_68406552adbc83288f63cff128dd5076