### PR TITLE
feat: display customer note on back office

### DIFF
--- a/views/templates/admin/verification/view.html.twig
+++ b/views/templates/admin/verification/view.html.twig
@@ -197,7 +197,22 @@
 				</div>
 			{% endif %}
 
-			{# Admin Notes Section #}
+                        {# Customer Note Section #}
+                        {% if verification.customer_note is defined and verification.customer_note %}
+                                <div class="card mt-3">
+                                        <div class="card-header">
+                                                <h4 class="card-header-title">
+                                                        <i class="material-icons">note</i>
+                                                        {{ 'Customer Note'|trans({}, 'Modules.Pskyc.Admin') }}
+                                                </h4>
+                                        </div>
+                                        <div class="card-body">
+                                                <p>{{ verification.customer_note|nl2br }}</p>
+                                        </div>
+                                </div>
+                        {% endif %}
+
+                        {# Admin Notes Section #}
 			<div class="card mt-3">
 				<div class="card-header">
 					<h4 class="card-header-title">


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

## Linked issue
<!-- Please link the issue this PR addresses. (if applicable) -->
Closes #4 

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Enhancement
- [ ] Documentation update
- [ ] Other (please describe):

## Description

- display the customer note on the admin verification details page
------
https://chatgpt.com/codex/tasks/task_e_6840656d68c48328adaf1293bb221c98