### PR TITLE
feat: add a redirection to customer profile on KYC page

### DIFF
--- a/src/Grid/Definition/Factory/VerificationGridDefinitionFactory.php
+++ b/src/Grid/Definition/Factory/VerificationGridDefinitionFactory.php
@@ -202,6 +202,16 @@ class VerificationGridDefinitionFactory extends AbstractGridDefinitionFactory
                         'route_param_field' => 'id_kyc_verification',
                         'clickable_row' => true,
                     ])
+            )
+            ->add(
+                (new LinkRowAction('customer'))
+                    ->setName($this->trans('Customer', [], 'Admin.Global'))
+                    ->setIcon('account_circle')
+                    ->setOptions([
+                        'route' => 'admin_customers_view',
+                        'route_param_name' => 'customerId',
+                        'route_param_field' => 'id_customer',
+                    ])
             );
     }
 }

--- a/views/templates/admin/verification/view.html.twig
+++ b/views/templates/admin/verification/view.html.twig
@@ -31,7 +31,7 @@
 							</h4>
 						</div>
 						<div class="card-body">
-							<table class="table table-striped">
+                                                        <table class="table table-striped">
 								<tr>
 									<td>
 										<strong>{{ 'Customer ID'|trans({}, 'Modules.Pskyc.Admin') }}:</strong>
@@ -51,7 +51,16 @@
 									<td>{{ verification.customer.firstname|default('-') }}
 										{{ verification.customer.lastname|default('-') }}</td>
 								</tr>
-							</table>
+                                                        </table>
+                                                        <a
+                                                                href="{{ path('admin_customers_view', {'customerId': verification.id_customer}) }}"
+                                                                class="btn btn-sm btn-outline-primary mt-2"
+                                                                target="_blank"
+                                                                rel="noopener"
+                                                        >
+                                                                <i class="material-icons">open_in_new</i>
+                                                                {{ 'View customer'|trans({}, 'Admin.Actions') }}
+                                                        </a>
 						</div>
 					</div>
 				</div>


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

## Linked issue
<!-- Please link the issue this PR addresses. (if applicable) -->
Closes #7 

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Enhancement
- [ ] Documentation update
- [ ] Other (please describe):

## Description

- add link to view customer record from admin grid
- add 'View customer' button on verification detail page

------
https://chatgpt.com/codex/tasks/task_e_68406587fe848328a2ccbb15300cf83f