### PR TITLE
fix: remove admin notes from status emails

### DIFF
--- a/mails/en/verification_status.html
+++ b/mails/en/verification_status.html
@@ -3,4 +3,3 @@
 <p>Verification ID: {verification_id}<br>
 Status: {status_label}<br>
 Date Submitted: {date_submitted}</p>
-<p>Message: {status_message}</p>

--- a/mails/en/verification_status.txt
+++ b/mails/en/verification_status.txt
@@ -5,5 +5,3 @@ Your KYC verification status has been updated.
 Verification ID: {verification_id}
 Status: {status_label}
 Date Submitted: {date_submitted}
-
-Message: {status_message}

--- a/mails/fr/verification_status.html
+++ b/mails/fr/verification_status.html
@@ -3,4 +3,3 @@
 <p>ID de vérification : {verification_id}<br>
 Statut : {status_label}<br>
 Date de soumission : {date_submitted}</p>
-<p>Message : {status_message}</p>

--- a/mails/fr/verification_status.txt
+++ b/mails/fr/verification_status.txt
@@ -5,5 +5,3 @@ Le statut de votre vérification KYC a été mis à jour.
 ID de vérification : {verification_id}
 Statut : {status_label}
 Date de soumission : {date_submitted}
-
-Message : {status_message}

--- a/mails/layouts/verification_status.html.twig
+++ b/mails/layouts/verification_status.html.twig
@@ -66,18 +66,7 @@
 							{/if}
 						</table>
 
-						<p>{status_message}</p>
-
-						{if isset($admin_note)}
-						<table class="table" cellpadding="10" cellspacing="0" style="width:100%; border: 1px solid {note_border_color}; background-color: {note_bg_color}; margin: 15px 0;">
-							<tr>
-								<td>
-									<strong>{note_title}:</strong><br>
-									{admin_note}
-								</td>
-							</tr>
-						</table>
-						{/if}
+                                                {# Admin notes are not sent to customers anymore #}
 
 						<table cellpadding="0" cellspacing="0" style="margin: 20px auto;">
 							<tr>

--- a/src/Service/NotificationService.php
+++ b/src/Service/NotificationService.php
@@ -64,7 +64,7 @@ class NotificationService
                 '{lastname}' => $customer['lastname'],
                 '{verification_id}' => $verification['id_kyc_verification'],
                 '{status_label}' => $this->getStatusLabel($verification['status']),
-                '{status_message}' => $verification['admin_note'] ?? '',
+                // Do not expose internal admin notes to customers
                 '{date_submitted}' => $verification['date_submitted'],
             ];
 

--- a/tests/PsKyc/MockProxy.php
+++ b/tests/PsKyc/MockProxy.php
@@ -154,8 +154,8 @@ class Mail extends MockProxy
      * Mock template content for testing
      */
     public static $mockTemplateContent = [
-        'html' => 'HTML: Hello {firstname} {lastname}, your verification #{verification_id} is {status_label}. Message: {status_message}',
-        'txt' => 'TXT: Hello {firstname} {lastname}, your verification #{verification_id} is {status_label}. Message: {status_message}',
+        'html' => 'HTML: Hello {firstname} {lastname}, your verification #{verification_id} is {status_label}',
+        'txt' => 'TXT: Hello {firstname} {lastname}, your verification #{verification_id} is {status_label}',
     ];
 
     /**
@@ -234,8 +234,8 @@ class Mail extends MockProxy
         ];
 
         static::$mockTemplateContent = [
-            'html' => 'HTML: Hello {firstname} {lastname}, your verification #{verification_id} is {status_label}. Message: {status_message}',
-            'txt' => 'TXT: Hello {firstname} {lastname}, your verification #{verification_id} is {status_label}. Message: {status_message}',
+            'html' => 'HTML: Hello {firstname} {lastname}, your verification #{verification_id} is {status_label}',
+            'txt' => 'TXT: Hello {firstname} {lastname}, your verification #{verification_id} is {status_label}',
         ];
     }
 

--- a/tests/PsKyc/Service/NotificationServiceTest.php
+++ b/tests/PsKyc/Service/NotificationServiceTest.php
@@ -761,8 +761,8 @@ class NotificationServiceTest extends MockeryTestCase
 
         // Set a custom template to test all variables used in status notifications
         \Mail::setMockTemplateContent(
-            'Dear {firstname} {lastname}, your KYC verification #{verification_id} status is now: {status_label}. Admin note: {status_message}. Submitted on: {date_submitted}.',
-            'TXT: Dear {firstname} {lastname}, verification #{verification_id} is {status_label}. Note: {status_message}. Date: {date_submitted}.'
+            'Dear {firstname} {lastname}, your KYC verification #{verification_id} status is now: {status_label}. Submitted on: {date_submitted}.',
+            'TXT: Dear {firstname} {lastname}, verification #{verification_id} is {status_label}. Date: {date_submitted}.'
         );
 
         $this->setupContextExpectations();
@@ -790,11 +790,11 @@ class NotificationServiceTest extends MockeryTestCase
         $this->assertEquals('jane.smith@example.com', $processedContent['recipient']);
 
         // Check that all template variables were properly replaced in HTML content
-        $expectedHtmlContent = 'Dear Jane Smith, your KYC verification #123 status is now: Approved. Admin note: All documents verified successfully. Submitted on: 2025-01-01 10:00:00.';
+        $expectedHtmlContent = 'Dear Jane Smith, your KYC verification #123 status is now: Approved. Submitted on: 2025-01-01 10:00:00.';
         $this->assertEquals($expectedHtmlContent, $processedContent['html']);
 
         // Check that all template variables were properly replaced in TXT content
-        $expectedTxtContent = 'TXT: Dear Jane Smith, verification #123 is Approved. Note: All documents verified successfully. Date: 2025-01-01 10:00:00.';
+        $expectedTxtContent = 'TXT: Dear Jane Smith, verification #123 is Approved. Date: 2025-01-01 10:00:00.';
         $this->assertEquals($expectedTxtContent, $processedContent['txt']);
 
         // Verify specific template variables were passed correctly
@@ -803,7 +803,6 @@ class NotificationServiceTest extends MockeryTestCase
         $this->assertEquals('Smith', $templateVars['{lastname}']);
         $this->assertEquals(123, $templateVars['{verification_id}']);
         $this->assertEquals('Approved', $templateVars['{status_label}']);
-        $this->assertEquals('All documents verified successfully', $templateVars['{status_message}']);
         $this->assertEquals('2025-01-01 10:00:00', $templateVars['{date_submitted}']);
     }
 
@@ -1051,8 +1050,8 @@ class NotificationServiceTest extends MockeryTestCase
 
             // Set a custom template to test status-specific variables
             \Mail::setMockTemplateContent(
-                'Dear {firstname} {lastname}, verification #{verification_id} status: {status_label}. Note: {status_message}. Submitted: {date_submitted}',
-                'TXT: {firstname} {lastname}, #{verification_id}: {status_label}. Note: {status_message}. Date: {date_submitted}'
+                'Dear {firstname} {lastname}, verification #{verification_id} status: {status_label}. Submitted: {date_submitted}',
+                'TXT: {firstname} {lastname}, #{verification_id}: {status_label}. Date: {date_submitted}'
             );
 
             $verification = array_merge($baseVerification, ['status' => $status]);
@@ -1088,7 +1087,6 @@ class NotificationServiceTest extends MockeryTestCase
             $this->assertEquals('User', $templateVars['{lastname}']);
             $this->assertEquals(100, $templateVars['{verification_id}']);
             $this->assertEquals($expectedLabel, $templateVars['{status_label}']);
-            $this->assertEquals('Test admin note', $templateVars['{status_message}']);
             $this->assertEquals('2025-01-01 10:00:00', $templateVars['{date_submitted}']);
         }
     }
@@ -1114,8 +1112,8 @@ class NotificationServiceTest extends MockeryTestCase
 
         // Set a custom template to test empty/missing values
         \Mail::setMockTemplateContent(
-            'Status: {status_label}, Note: "{status_message}"',
-            'TXT: Status: {status_label}, Note: "{status_message}"'
+            'Status: {status_label}',
+            'TXT: Status: {status_label}'
         );
 
         $this->setupContextExpectations();
@@ -1140,10 +1138,9 @@ class NotificationServiceTest extends MockeryTestCase
         // Verify that empty admin_note is handled correctly
         $templateVars = $processedContent['templateVars'];
         $this->assertEquals('Pending Review', $templateVars['{status_label}']);
-        $this->assertEquals('', $templateVars['{status_message}']); // Should be empty string when admin_note is missing
 
         // Check that empty values are properly replaced in content
-        $expectedHtmlContent = 'Status: Pending Review, Note: ""';
+        $expectedHtmlContent = 'Status: Pending Review';
         $this->assertEquals($expectedHtmlContent, $processedContent['html']);
     }
 
@@ -1168,8 +1165,8 @@ class NotificationServiceTest extends MockeryTestCase
 
         // Set a custom template to test special characters
         \Mail::setMockTemplateContent(
-            'Customer: {firstname} {lastname}, Note: {status_message}',
-            'TXT: Customer: {firstname} {lastname}, Note: {status_message}'
+            'Customer: {firstname} {lastname}',
+            'TXT: Customer: {firstname} {lastname}'
         );
 
         $this->setupContextExpectations();
@@ -1195,10 +1192,9 @@ class NotificationServiceTest extends MockeryTestCase
         $templateVars = $processedContent['templateVars'];
         $this->assertEquals('José', $templateVars['{firstname}']);
         $this->assertEquals('García-López', $templateVars['{lastname}']);
-        $this->assertEquals('Documents verified with special chars: àáâãäåæçèéêë & symbols!', $templateVars['{status_message}']);
 
         // Check that special characters are properly replaced in content
-        $expectedHtmlContent = 'Customer: José García-López, Note: Documents verified with special chars: àáâãäåæçèéêë & symbols!';
+        $expectedHtmlContent = 'Customer: José García-López';
         $this->assertEquals($expectedHtmlContent, $processedContent['html']);
     }
 


### PR DESCRIPTION
## Summary
- do not include admin notes in status notification emails
- clean up email templates
- update tests

## Testing
- `composer test`
- `composer lint-check`


------
https://chatgpt.com/codex/tasks/task_e_6846a94677648328b7cdca1d1cf473f9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Removed the display of detailed status messages and internal admin notes from verification status notification emails in both English and French.
- **Tests**
	- Updated tests to reflect the removal of status message and admin note content from email templates.
- **Style**
	- Minor formatting adjustments, such as removing trailing newlines in email templates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->