### PR TITLE
feat: notify admins on verification status changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- Admin email notification when verification status changes
+
 ## [1.1.1] - 2025-06-05
 
 ### Fixed

--- a/mails/en/admin_verification_status.html
+++ b/mails/en/admin_verification_status.html
@@ -1,0 +1,6 @@
+<p>Verification #{verification_id} status updated to {status_label}.</p>
+<p>Customer: {customer_name} ({customer_email})<br>
+Customer ID: #{customer_id}</p>
+<p>Message: {status_message}</p>
+<p>Review in Admin Panel: {admin_verification_url}</p>
+<p>This is an automated admin notification.</p>

--- a/mails/en/admin_verification_status.txt
+++ b/mails/en/admin_verification_status.txt
@@ -1,0 +1,9 @@
+Verification #{verification_id} status updated to {status_label}.
+
+Customer: {customer_name} ({customer_email})
+Customer ID: #{customer_id}
+Message: {status_message}
+
+Review in Admin Panel: {admin_verification_url}
+
+This is an automated admin notification.

--- a/mails/fr/admin_verification_status.html
+++ b/mails/fr/admin_verification_status.html
@@ -1,0 +1,6 @@
+<p>Le statut de la vérification #{verification_id} a été mis à jour en {status_label}.</p>
+<p>Client : {customer_name} ({customer_email})<br>
+Identifiant client : #{customer_id}</p>
+<p>Message : {status_message}</p>
+<p>Examen dans le panneau d'administration : {admin_verification_url}</p>
+<p>Il s'agit d'une notification administrative automatisée.</p>

--- a/mails/fr/admin_verification_status.txt
+++ b/mails/fr/admin_verification_status.txt
@@ -1,0 +1,9 @@
+Le statut de la vérification #{verification_id} a été mis à jour en {status_label}.
+
+Client : {customer_name} ({customer_email})
+Identifiant client : #{customer_id}
+Message : {status_message}
+
+Examen dans le panneau d'administration : {admin_verification_url}
+
+Il s'agit d'une notification administrative automatisée.

--- a/src/Service/MaintenanceService.php
+++ b/src/Service/MaintenanceService.php
@@ -215,6 +215,11 @@ class MaintenanceService
                                 $customer,
                                 'approved'
                             );
+                            // Notify administrators of the status change
+                            $this->notificationService->sendAdminStatusChangeNotification(
+                                $verification,
+                                $customer
+                            );
                             if ($sent) {
                                 ++$results['notifications_sent'];
                             }

--- a/src/Service/NotificationService.php
+++ b/src/Service/NotificationService.php
@@ -188,6 +188,58 @@ class NotificationService
     }
 
     /**
+     * Send admin notification for verification status change
+     *
+     * Notifies administrators when a customer's verification status is updated
+     *
+     * @param array $verification Verification record from database
+     * @param array $customer Customer record from database
+     *
+     * @return bool True if email was sent successfully, false otherwise
+     */
+    public function sendAdminStatusChangeNotification(array $verification, array $customer): bool
+    {
+        try {
+            $adminEmails = $this->getAdminEmails();
+
+            if (empty($adminEmails)) {
+                return false;
+            }
+
+            $templateVars = [
+                '{customer_name}' => $customer['firstname'] . ' ' . $customer['lastname'],
+                '{customer_email}' => $customer['email'],
+                '{customer_id}' => $customer['id_customer'],
+                '{verification_id}' => $verification['id_kyc_verification'],
+                '{status_label}' => $this->getStatusLabel($verification['status']),
+                '{status_message}' => $verification['admin_note'] ?? '',
+                '{admin_verification_url}' => $this->context->shop->getBaseURL(true),
+            ];
+
+            $subject = $this->getEmailSubjectForStatus($verification['status']);
+
+            $success = true;
+            foreach ($adminEmails as $adminEmail) {
+                $result = $this->sendThemeEmail(
+                    'admin_verification_status',
+                    $subject,
+                    $templateVars,
+                    $adminEmail['email'],
+                    $adminEmail['name'],
+                    \Configuration::get('PS_LANG_DEFAULT')
+                );
+                $success = $success && $result;
+            }
+
+            return $success;
+        } catch (\Exception $e) {
+            \PrestaShopLogger::addLog('KYC admin notification error: ' . $e->getMessage(), 3, null, 'Pskyc');
+
+            return false;
+        }
+    }
+
+    /**
      * Send expiry warning notification to customer
      *
      * Warns customers that their documents will expire soon

--- a/src/Service/VerificationService.php
+++ b/src/Service/VerificationService.php
@@ -376,6 +376,12 @@ class VerificationService
                             $customerData,
                             $previousStatus
                         );
+
+                        // Notify administrators of the status change
+                        $this->notificationService->sendAdminStatusChangeNotification(
+                            $updatedVerification,
+                            $customerData
+                        );
                     }
                 }
 

--- a/tests/PsKyc/Service/NotificationServiceTest.php
+++ b/tests/PsKyc/Service/NotificationServiceTest.php
@@ -1495,6 +1495,11 @@ class NotificationServiceTest extends MockeryTestCase
             ->once();
 
         $this->setupContextExpectations();
+        \Mail::resetMockState();
+        \Mail::setMockTemplateContent(
+            'Verification #{verification_id} for {customer_name} ({customer_email}) was {status_label}: {status_message}. URL: {admin_verification_url}',
+            'TXT: #{verification_id} {status_label} {status_message} {admin_verification_url}'
+        );
         $this->setupMailExpectations(true);
 
         $this->translatorMock->shouldReceive('trans')
@@ -1508,6 +1513,25 @@ class NotificationServiceTest extends MockeryTestCase
         $result = $this->service->sendAdminStatusChangeNotification($verification, $customer);
 
         $this->assertTrue($result);
+
+        $processedContent = \Mail::getLastProcessedContent();
+        $this->assertEquals('admin_verification_status', $processedContent['template']);
+        $this->assertEquals('KYC Verification Approved', $processedContent['subject']);
+        $this->assertEquals('admin@example.com', $processedContent['recipient']);
+
+        $expectedHtml = 'Verification #5 for Adam West (adam.west@example.com) was Approved: ok. URL: https://example.com/';
+        $this->assertEquals($expectedHtml, $processedContent['html']);
+        $expectedTxt = 'TXT: #5 Approved ok https://example.com/';
+        $this->assertEquals($expectedTxt, $processedContent['txt']);
+
+        $templateVars = $processedContent['templateVars'];
+        $this->assertEquals('Adam West', $templateVars['{customer_name}']);
+        $this->assertEquals('adam.west@example.com', $templateVars['{customer_email}']);
+        $this->assertEquals(10, $templateVars['{customer_id}']);
+        $this->assertEquals(5, $templateVars['{verification_id}']);
+        $this->assertEquals('Approved', $templateVars['{status_label}']);
+        $this->assertEquals('ok', $templateVars['{status_message}']);
+        $this->assertEquals('https://example.com/', $templateVars['{admin_verification_url}']);
     }
 
     public function testSendAdminStatusChangeNotificationAdminEmailsEmpty()
@@ -1592,7 +1616,18 @@ class NotificationServiceTest extends MockeryTestCase
             ->once();
 
         $this->setupContextExpectations();
-        \Mail::shouldReceive('Send')->twice()->andReturn(true);
+        \Mail::shouldReceive('Send')
+            ->once()
+            ->withArgs(function ($langId, $template, $subject, $vars, $to) {
+                return $to === 'admin1@example.com' && $template === 'admin_verification_status';
+            })
+            ->andReturn(true);
+        \Mail::shouldReceive('Send')
+            ->once()
+            ->withArgs(function ($langId, $template, $subject, $vars, $to) {
+                return $to === 'admin2@example.com' && $template === 'admin_verification_status';
+            })
+            ->andReturn(true);
 
         $this->translatorMock->shouldReceive('trans')
             ->with('Approved', [], 'Modules.Pskyc.Shop')

--- a/tests/PsKyc/Service/NotificationServiceTest.php
+++ b/tests/PsKyc/Service/NotificationServiceTest.php
@@ -1524,4 +1524,213 @@ class NotificationServiceTest extends MockeryTestCase
 
         $this->assertFalse($result);
     }
+
+    public function testSendAdminStatusChangeNotificationExceptionHandling()
+    {
+        $verification = [
+            'id_kyc_verification' => 6,
+            'status' => 'approved',
+        ];
+
+        $customer = [
+            'firstname' => 'Eve',
+            'lastname' => 'Adams',
+            'email' => 'eve.adams@example.com',
+            'id_customer' => 11,
+        ];
+
+        \Configuration::shouldReceive('get')
+            ->with('PSKYC_ADMIN_EMAILS')
+            ->andReturn('admin@example.com')
+            ->once();
+
+        \Validate::shouldReceive('isEmail')
+            ->with('admin@example.com')
+            ->andReturn(true)
+            ->once();
+
+        $this->translatorMock->shouldReceive('trans')
+            ->with('Approved', [], 'Modules.Pskyc.Shop')
+            ->andThrow(new \Exception('Translator failed'));
+
+        \PrestaShopLogger::shouldReceive('addLog')
+            ->once()
+            ->with(\Mockery::pattern('/KYC admin notification error:/'), 3, null, 'Pskyc');
+
+        $result = $this->service->sendAdminStatusChangeNotification($verification, $customer);
+
+        $this->assertFalse($result);
+    }
+
+    public function testSendAdminStatusChangeNotificationMultipleEmails()
+    {
+        $verification = [
+            'id_kyc_verification' => 7,
+            'status' => 'approved',
+        ];
+
+        $customer = [
+            'firstname' => 'Jane',
+            'lastname' => 'Doe',
+            'email' => 'jane.doe@example.com',
+            'id_customer' => 12,
+        ];
+
+        \Configuration::shouldReceive('get')
+            ->with('PSKYC_ADMIN_EMAILS')
+            ->andReturn('admin1@example.com, admin2@example.com')
+            ->once();
+
+        \Validate::shouldReceive('isEmail')
+            ->with('admin1@example.com')
+            ->andReturn(true)
+            ->once();
+
+        \Validate::shouldReceive('isEmail')
+            ->with('admin2@example.com')
+            ->andReturn(true)
+            ->once();
+
+        $this->setupContextExpectations();
+        \Mail::shouldReceive('Send')->twice()->andReturn(true);
+
+        $this->translatorMock->shouldReceive('trans')
+            ->with('Approved', [], 'Modules.Pskyc.Shop')
+            ->andReturn('Approved');
+
+        $this->translatorMock->shouldReceive('trans')
+            ->with('KYC Verification Approved', [], 'Modules.Pskyc.Shop')
+            ->andReturn('KYC Verification Approved');
+
+        $result = $this->service->sendAdminStatusChangeNotification($verification, $customer);
+
+        $this->assertTrue($result);
+
+        $processedContent = \Mail::getLastProcessedContent();
+        $this->assertEquals('admin2@example.com', $processedContent['recipient']);
+    }
+
+    public function testSendAdminStatusChangeNotificationInvalidEmailsFallback()
+    {
+        $verification = [
+            'id_kyc_verification' => 8,
+            'status' => 'approved',
+        ];
+
+        $customer = [
+            'firstname' => 'Paul',
+            'lastname' => 'Smith',
+            'email' => 'paul.smith@example.com',
+            'id_customer' => 13,
+        ];
+
+        \Configuration::shouldReceive('get')
+            ->with('PSKYC_ADMIN_EMAILS')
+            ->andReturn('invalid-email')
+            ->once();
+
+        \Validate::shouldReceive('isEmail')
+            ->with('invalid-email')
+            ->andReturn(false)
+            ->once();
+
+        \Configuration::shouldReceive('get')
+            ->with('PS_SHOP_EMAIL')
+            ->andReturn('shop@example.com')
+            ->once();
+
+        \Validate::shouldReceive('isEmail')
+            ->with('shop@example.com')
+            ->andReturn(true)
+            ->once();
+
+        \Configuration::shouldReceive('get')
+            ->with('PS_SHOP_NAME')
+            ->andReturn('Test Shop')
+            ->once();
+
+        $this->setupContextExpectations();
+        $this->setupMailExpectations(true);
+
+        $this->translatorMock->shouldReceive('trans')
+            ->with('Approved', [], 'Modules.Pskyc.Shop')
+            ->andReturn('Approved');
+
+        $this->translatorMock->shouldReceive('trans')
+            ->with('KYC Verification Approved', [], 'Modules.Pskyc.Shop')
+            ->andReturn('KYC Verification Approved');
+
+        $result = $this->service->sendAdminStatusChangeNotification($verification, $customer);
+
+        $this->assertTrue($result);
+
+        $processedContent = \Mail::getLastProcessedContent();
+        $this->assertEquals('shop@example.com', $processedContent['recipient']);
+    }
+
+    public function testSendAdminStatusChangeNotificationTemplateVariables()
+    {
+        $verification = [
+            'id_kyc_verification' => 9,
+            'status' => 'rejected',
+            'admin_note' => 'Bad docs',
+        ];
+
+        $customer = [
+            'firstname' => 'Sarah',
+            'lastname' => 'Connor',
+            'email' => 's.connor@example.com',
+            'id_customer' => 14,
+        ];
+
+        \Mail::resetMockState();
+        \Mail::setMockTemplateContent(
+            'Verification #{verification_id} for {customer_name} was {status_label}: {status_message}. URL: {admin_verification_url}',
+            'TXT: #{verification_id} {status_label} {status_message} {admin_verification_url}'
+        );
+
+        \Configuration::shouldReceive('get')
+            ->with('PSKYC_ADMIN_EMAILS')
+            ->andReturn('admin@example.com')
+            ->once();
+
+        \Validate::shouldReceive('isEmail')
+            ->with('admin@example.com')
+            ->andReturn(true)
+            ->once();
+
+        $this->setupContextExpectations();
+        $this->setupMailExpectations(true);
+
+        $this->translatorMock->shouldReceive('trans')
+            ->with('Rejected', [], 'Modules.Pskyc.Shop')
+            ->andReturn('Rejected');
+
+        $this->translatorMock->shouldReceive('trans')
+            ->with('KYC Verification Rejected', [], 'Modules.Pskyc.Shop')
+            ->andReturn('KYC Verification Rejected');
+
+        $result = $this->service->sendAdminStatusChangeNotification($verification, $customer);
+
+        $this->assertTrue($result);
+
+        $processedContent = \Mail::getLastProcessedContent();
+        $this->assertEquals('admin_verification_status', $processedContent['template']);
+        $this->assertEquals('KYC Verification Rejected', $processedContent['subject']);
+        $this->assertEquals('admin@example.com', $processedContent['recipient']);
+
+        $expectedHtml = 'Verification #9 for Sarah Connor was Rejected: Bad docs. URL: https://example.com/';
+        $this->assertEquals($expectedHtml, $processedContent['html']);
+        $expectedTxt = 'TXT: #9 Rejected Bad docs https://example.com/';
+        $this->assertEquals($expectedTxt, $processedContent['txt']);
+
+        $templateVars = $processedContent['templateVars'];
+        $this->assertEquals('Sarah Connor', $templateVars['{customer_name}']);
+        $this->assertEquals('s.connor@example.com', $templateVars['{customer_email}']);
+        $this->assertEquals(14, $templateVars['{customer_id}']);
+        $this->assertEquals(9, $templateVars['{verification_id}']);
+        $this->assertEquals('Rejected', $templateVars['{status_label}']);
+        $this->assertEquals('Bad docs', $templateVars['{status_message}']);
+        $this->assertEquals('https://example.com/', $templateVars['{admin_verification_url}']);
+    }
 }

--- a/tests/PsKyc/Service/NotificationServiceTest.php
+++ b/tests/PsKyc/Service/NotificationServiceTest.php
@@ -1472,4 +1472,60 @@ class NotificationServiceTest extends MockeryTestCase
         $this->assertEquals('admin1@example.com', $result[0]['email']);
         $this->assertEquals('admin2@example.com', $result[1]['email']);
     }
+
+    public function testSendAdminStatusChangeNotificationSuccess()
+    {
+        $verification = [
+            'id_kyc_verification' => 5,
+            'status' => 'approved',
+            'admin_note' => 'ok',
+        ];
+
+        $customer = [
+            'firstname' => 'Adam',
+            'lastname' => 'West',
+            'email' => 'adam.west@example.com',
+            'id_customer' => 10,
+        ];
+
+        \Configuration::shouldReceive('get')
+            ->with('PSKYC_ADMIN_EMAILS')
+            ->andReturn('admin@example.com')
+            ->once();
+
+        \Validate::shouldReceive('isEmail')
+            ->with('admin@example.com')
+            ->andReturn(true)
+            ->once();
+
+        $this->setupContextExpectations();
+        $this->setupMailExpectations(true);
+
+        $this->translatorMock->shouldReceive('trans')
+            ->with('Approved', [], 'Modules.Pskyc.Shop')
+            ->andReturn('Approved');
+
+        $this->translatorMock->shouldReceive('trans')
+            ->with('KYC Verification Approved', [], 'Modules.Pskyc.Shop')
+            ->andReturn('KYC Verification Approved');
+
+        $result = $this->service->sendAdminStatusChangeNotification($verification, $customer);
+
+        $this->assertTrue($result);
+    }
+
+    public function testSendAdminStatusChangeNotificationAdminEmailsEmpty()
+    {
+        $verification = ['id_kyc_verification' => 5, 'status' => 'approved'];
+        $customer = ['firstname' => 'Adam', 'lastname' => 'West', 'email' => 'adam.west@example.com', 'id_customer' => 10];
+
+        \Configuration::shouldReceive('get')
+            ->with('PSKYC_ADMIN_EMAILS')
+            ->andReturn('')
+            ->once();
+
+        $result = $this->service->sendAdminStatusChangeNotification($verification, $customer);
+
+        $this->assertFalse($result);
+    }
 }


### PR DESCRIPTION
## Linked issue
Closes #20

## Type of change
- [x] Enhancement

## Description
Adds email notifications for admins when a customer verification status changes. Includes new email templates, service method, and tests.

## How to test
- Run unit tests using `composer test`
- Verify new admin emails are sent when status updates occur.

## Checklist
- [x] I have read the CONTRIBUTING guidelines.
- [ ] Lint and tests pass locally.
- [ ] I have updated documentation where relevant.
- [x] I have added tests where possible.
- [x] The code is in English and follows PrestaShop module conventions.

------
https://chatgpt.com/codex/tasks/task_e_6846a95849988328931415c15d1bb6d3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced email notifications for administrators when a customer's verification status changes, with templates available in both English and French.
- **Documentation**
  - Updated the changelog to include the new admin email notification feature.
- **Tests**
  - Added tests to ensure admin notification emails are sent correctly, handle multiple recipients, fallback scenarios, and error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->