### PR TITLE
chore: declare prestashop 9 compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        presta-versions: ['8.0', '8.1', '8.2']
+        presta-versions: ['8.0', '8.1', '8.2', '9.0']
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # KYC Secure Upload - AI Agent Guide
 
-Welcome to the KYC Secure Upload project! This document provides essential information for AI agents and developers contributing to this PrestaShop 8 module.
+Welcome to the KYC Secure Upload project! This document provides essential information for AI agents and developers contributing to this PrestaShop 8/9 module.
 
 ## 📋 Project Overview
 
@@ -134,7 +134,7 @@ git push origin feat/customer-document-preview
 - **Unit Tests**: All new services and repositories must have tests
 - **Integration Tests**: Test admin controllers and front workflows
 - **Coverage**: Maintain 90%+ test coverage
-- **Manual Testing**: Test in PrestaShop 8.0+ environment
+- **Manual Testing**: Test in PrestaShop 8.0+ and 9.0+ environments
 
 ## 📝 Changelog Management
 
@@ -193,6 +193,7 @@ We follow [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) format in `CH
 ## 📚 Resources
 
 - [PrestaShop 8 Module Documentation](https://devdocs.prestashop-project.org/8/modules/)
+- [PrestaShop 9 Module Documentation](https://devdocs.prestashop-project.org/9/modules/)
 - [Project Contributing Guidelines](CONTRIBUTING.md)
 - [Changelog](CHANGELOG.md)
 - [License](LICENSE.md)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Official PrestaShop 9 compatibility documentation and CI coverage
+
 ### Fixed
 - Fix remove admin note in status mail notification
 - Escape KYC form validation messages and loading labels for safe front-office JavaScript handling when two-sided IDs are required
@@ -70,6 +73,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Ready for PrestaShop 8.0+ environments
 - Please report any issues on GitHub
 
-[Unreleased]: https://github.com/vachmara/pskyc/compare/v1.1.0...HEAD
+[Unreleased]: https://github.com/vachmara/pskyc/compare/v1.1.1...HEAD
 [1.1.0]: https://github.com/vachmara/pskyc/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/vachmara/pskyc/releases/tag/v1.0.0

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Open source, GDPR-compliant KYC document verification for PrestaShop.
 ## Requirements
 
 ### PrestaShop Compatibility
-- **PrestaShop:** 8.0.x – 9.0.x
+- **PrestaShop:** 8.x – 9.x
 
 #### Tested PrestaShop releases
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![PHP Version](https://img.shields.io/badge/PHP-8.1%2B-blue.svg)](https://www.php.net/)
-[![PrestaShop](https://img.shields.io/badge/PrestaShop-8.0%2B-orange.svg)](https://www.prestashop.com/)
+[![PrestaShop](https://img.shields.io/badge/PrestaShop-8.x%20%26%209.x-orange.svg)](https://www.prestashop.com/)
 [![Packagist Version](https://img.shields.io/packagist/v/vachmara/pskyc.svg)](https://packagist.org/packages/vachmara/pskyc)
 [![Packagist Downloads](https://img.shields.io/packagist/dt/vachmara/pskyc.svg)](https://packagist.org/packages/vachmara/pskyc)
 [![CI Tests](https://github.com/vachmara/pskyc/workflows/CI%20Tests/badge.svg)](https://github.com/vachmara/pskyc/actions)
@@ -20,7 +20,11 @@ Open source, GDPR-compliant KYC document verification for PrestaShop.
 ## Requirements
 
 ### PrestaShop Compatibility
-- **PrestaShop:** 8.0.0 or higher
+- **PrestaShop:** 8.0.x – 9.0.x
+
+#### Tested PrestaShop releases
+
+Official continuous integration covers PrestaShop 8.0, 8.1, 8.2 and 9.0 Docker images to ensure ongoing compatibility across both major branches.
 - **PHP:** 8.1 or higher
 
 ### PHP Extensions
@@ -33,7 +37,7 @@ This module uses standard PrestaShop-required PHP extensions:
 - **json** - For configuration data (standard PrestaShop requirement)
 - **mbstring** - For string handling (standard PrestaShop requirement)
 
-*All listed extensions are standard PrestaShop 8 requirements, so no additional server configuration is needed.*
+*All listed extensions are standard PrestaShop 8/9 requirements, so no additional server configuration is needed.*
 
 ## Features
 

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "type": "prestashop-module",
     "name": "vachmara/pskyc",
-    "description": "Open source, GDPR-compliant KYC document verification for PrestaShop 8.",
+    "description": "Open source, GDPR-compliant KYC document verification for PrestaShop 8 and 9.",
     "license": "MIT",
     "homepage": "https://github.com/vachmara/pskyc",
     "keywords": [

--- a/controllers/front/verify.php
+++ b/controllers/front/verify.php
@@ -440,7 +440,7 @@ class PskycVerifyModuleFrontController extends ModuleFrontController
     {
         try {
             $customerRepository = $this->module->get('PrestaShop\Module\Pskyc\Repository\CustomerRepository');
-            if ($customerRepository === false) {
+            if (!$customerRepository) {
                 return null;
             }
             $customerData = $customerRepository->getCustomerData($customerId);

--- a/pskyc.php
+++ b/pskyc.php
@@ -60,9 +60,9 @@ class Pskyc extends Module
         $this->confirmUninstall = $warning;
         $this->confirmReset = $warning;
 
-        $this->ps_versions_compliancy = ['min' => '8.0', 'max' => '8.2'];
+        $this->ps_versions_compliancy = ['min' => '8.0', 'max' => '9.9.99'];
 
-        // Define admin tabs following PrestaShop 8 official documentation
+        // Define admin tabs following modern PrestaShop 8/9 official documentation
         $this->tabs = [
             [
                 'route_name' => 'ps_pskyc_verification_index',

--- a/pskyc.php
+++ b/pskyc.php
@@ -187,7 +187,7 @@ class Pskyc extends Module
         $verificationUrl = '';
         try {
             $router = $this->get('router');
-            if ($router !== false) {
+            if (!$router) {
                 $verificationUrl = $router->generate('ps_pskyc_verification_index');
             }
         } catch (Exception $e) {
@@ -440,7 +440,7 @@ class Pskyc extends Module
 
         // Render the Twig template instead of Smarty
         $twig = $this->get('twig');
-        if ($twig === false) {
+        if (!$twig) {
             return;
         }
 

--- a/pskyc.php
+++ b/pskyc.php
@@ -187,7 +187,7 @@ class Pskyc extends Module
         $verificationUrl = '';
         try {
             $router = $this->get('router');
-            if (!$router) {
+            if ($router) {
                 $verificationUrl = $router->generate('ps_pskyc_verification_index');
             }
         } catch (Exception $e) {

--- a/src/Controller/Admin/DocumentController.php
+++ b/src/Controller/Admin/DocumentController.php
@@ -110,10 +110,9 @@ class DocumentController extends FrameworkBundleAdminController
      */
     public function updateStatusAction(int $verificationId, Request $request, CsrfTokenManagerInterface $csrfTokenManager)
     {
-        $documentsData = $request->request->has('documents')
-            ? $request->request->all('documents')
-            : [];
-
+        $documentsData = $request->request->get('documents'); 
+        $documentsData = is_array($documentsData) ? $documentsData : [];
+        
         $token = (string) $request->request->get('_token', '');
         if (!$csrfTokenManager->isTokenValid(new \Symfony\Component\Security\Csrf\CsrfToken('pskyc_document_update', $token))) {
             $this->addFlash('error', $this->trans('Invalid CSRF token.', 'Modules.Pskyc.Admin'));

--- a/src/Controller/Admin/DocumentController.php
+++ b/src/Controller/Admin/DocumentController.php
@@ -110,8 +110,14 @@ class DocumentController extends FrameworkBundleAdminController
      */
     public function updateStatusAction(int $verificationId, Request $request, CsrfTokenManagerInterface $csrfTokenManager)
     {
-        $documentsData = $request->request->get('documents');
-        $documentsData = is_array($documentsData) ? $documentsData : [];
+        $payload = $request->request->all();
+
+        $documentsData = $payload['documents'] ?? [];
+
+        // normalize to array
+        if (!is_array($documentsData)) {
+            $documentsData = [];
+        }
 
         $token = (string) $request->request->get('_token', '');
         if (!$csrfTokenManager->isTokenValid(new \Symfony\Component\Security\Csrf\CsrfToken('pskyc_document_update', $token))) {

--- a/src/Controller/Admin/DocumentController.php
+++ b/src/Controller/Admin/DocumentController.php
@@ -110,9 +110,9 @@ class DocumentController extends FrameworkBundleAdminController
      */
     public function updateStatusAction(int $verificationId, Request $request, CsrfTokenManagerInterface $csrfTokenManager)
     {
-        $documentsData = $request->request->get('documents'); 
+        $documentsData = $request->request->get('documents');
         $documentsData = is_array($documentsData) ? $documentsData : [];
-        
+
         $token = (string) $request->request->get('_token', '');
         if (!$csrfTokenManager->isTokenValid(new \Symfony\Component\Security\Csrf\CsrfToken('pskyc_document_update', $token))) {
             $this->addFlash('error', $this->trans('Invalid CSRF token.', 'Modules.Pskyc.Admin'));

--- a/src/Controller/Admin/DocumentController.php
+++ b/src/Controller/Admin/DocumentController.php
@@ -110,8 +110,11 @@ class DocumentController extends FrameworkBundleAdminController
      */
     public function updateStatusAction(int $verificationId, Request $request, CsrfTokenManagerInterface $csrfTokenManager)
     {
-        $documentsData = $request->request->get('documents', []);
-        $token = $request->request->get('_token');
+        $documentsData = $request->request->has('documents')
+            ? $request->request->all('documents')
+            : [];
+
+        $token = (string) $request->request->get('_token', '');
         if (!$csrfTokenManager->isTokenValid(new \Symfony\Component\Security\Csrf\CsrfToken('pskyc_document_update', $token))) {
             $this->addFlash('error', $this->trans('Invalid CSRF token.', 'Modules.Pskyc.Admin'));
 

--- a/src/Service/NotificationService.php
+++ b/src/Service/NotificationService.php
@@ -19,7 +19,7 @@ use Symfony\Component\Translation\TranslatorInterface;
 /**
  * Class NotificationService
  *
- * Handles email notifications for KYC verification status changes using PrestaShop 8's modern email theme system
+ * Handles email notifications for KYC verification status changes using PrestaShop 8/9's modern email theme system
  * Sends automated emails to customers and administrators
  */
 class NotificationService

--- a/src/Service/NotificationService.php
+++ b/src/Service/NotificationService.php
@@ -14,7 +14,7 @@ namespace PrestaShop\Module\Pskyc\Service;
 if (!defined('_PS_VERSION_')) {
     exit;
 }
-use Symfony\Component\Translation\TranslatorInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
  * Class NotificationService

--- a/tests/PsKyc/Service/NotificationServiceTest.php
+++ b/tests/PsKyc/Service/NotificationServiceTest.php
@@ -14,11 +14,11 @@ namespace Tests\PsKyc\Service;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
 use PrestaShop\Module\Pskyc\Service\NotificationService;
 use Symfony\Component\Templating\EngineInterface;
-use Symfony\Component\Translation\TranslatorInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 class NotificationServiceTest extends MockeryTestCase
 {
-    /** @var TranslatorInterface */
+    /** @var \Symfony\Contracts\Translation\TranslatorInterface */
     private $translatorMock;
 
     /** @var EngineInterface */

--- a/tests/PsKyc/Service/NotificationServiceTest.php
+++ b/tests/PsKyc/Service/NotificationServiceTest.php
@@ -18,7 +18,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 class NotificationServiceTest extends MockeryTestCase
 {
-    /** @var \Symfony\Contracts\Translation\TranslatorInterface */
+    /** @var TranslatorInterface */
     private $translatorMock;
 
     /** @var EngineInterface */

--- a/tests/phpstan/phpstan-9.0.neon
+++ b/tests/phpstan/phpstan-9.0.neon
@@ -1,0 +1,2 @@
+includes:
+        - %currentWorkingDirectory%/tests/phpstan/phpstan.neon


### PR DESCRIPTION
## Linked issue
Closes #26

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Enhancement
- [x] Documentation update
- [ ] Other (please describe):

## Description

- Document official PrestaShop 9 compatibility across the README, composer metadata, and contributor guide.
- Extend the module compatibility declaration and changelog to reflect 8.x–9.x support.
- Update the CI pipeline to include a PrestaShop 9 static analysis job and add the corresponding PHPStan preset.

## How to test

1. composer lint
2. composer test
3. composer test:coverage

## Checklist

- [x] I have read the CONTRIBUTING guidelines.
- [x] Lint and tests pass locally.
- [x] I have updated documentation where relevant.
- [ ] I have added tests where possible.
- [x] The code is in English and follows PrestaShop module conventions.


------
https://chatgpt.com/codex/tasks/task_e_68cac6e245648328a3c55c1cc2357190

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Documentation
  - Updated README, AGENTS.md and CHANGELOG to announce and document PrestaShop 8.x–9.x compatibility; added tested releases section, badges, and PrestaShop 9 docs link.
- Chores
  - CI matrix expanded to include PrestaShop 9.0.
- Tests
  - Added PHPStan configuration for PrestaShop 9.0.
- Bug Fixes
  - Improved admin document handling to be more robust with incoming data and tokens.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->